### PR TITLE
Use tagged union for common shape behavior

### DIFF
--- a/src/examples/silhouette.zig
+++ b/src/examples/silhouette.zig
@@ -6,8 +6,8 @@ const Canvas = @import("../raytracer/canvas.zig").Canvas;
 const Tuple = @import("../raytracer/tuple.zig").Tuple;
 const Matrix = @import("../raytracer/matrix.zig").Matrix;
 const Ray = @import("../raytracer/ray.zig").Ray;
-const Sphere = @import("../raytracer/shapes/sphere.zig").Sphere;
-const hit = @import("../raytracer/shapes/sphere.zig").hit;
+const Shape = @import("../raytracer/shapes/shape.zig").Shape;
+const hit = @import("../raytracer/shapes/shape.zig").hit;
 
 pub fn drawSilhouette() !void {
     comptime var canvas_size = 100;
@@ -18,7 +18,7 @@ pub fn drawSilhouette() !void {
 
     var canvas = try Canvas(f32).new(allocator, canvas_size, canvas_size);
 
-    var s = Sphere(f32).new();
+    var s = Shape(f32).sphere();
     try s.setTransform(Matrix(f32, 4).identity().scale(1.3, 1.0, 1.0).translate(0.5, 0.5, 0.0));
     const source = Tuple(f32).point(0.0, 0.0, -5.0);
 

--- a/src/examples/simple_world.zig
+++ b/src/examples/simple_world.zig
@@ -5,7 +5,7 @@ const Tuple = @import("../raytracer/tuple.zig").Tuple;
 const Matrix = @import("../raytracer/matrix.zig").Matrix;
 const Color = @import("../raytracer/color.zig").Color;
 const Material = @import("../raytracer/material.zig").Material;
-const Sphere = @import("../raytracer/shapes/sphere.zig").Sphere;
+const Shape = @import("../raytracer/shapes/shape.zig").Shape;
 const Light = @import("../raytracer/light.zig").Light;
 const World = @import("../raytracer/world.zig").World;
 const Camera = @import("../raytracer/camera.zig").Camera;
@@ -17,12 +17,12 @@ pub fn renderSimpleWorld() !void {
 
     const identity = Matrix(f64, 4).identity();
 
-    var floor = Sphere(f64).new();
+    var floor = Shape(f64).sphere();
     try floor.setTransform(identity.scale(10.0, 0.01, 10.0));
     floor.material.color = Color(f64).new(1, 0.9, 0.9);
     floor.material.specular = 0.0;
 
-    var left_wall = Sphere(f64).new();
+    var left_wall = Shape(f64).sphere();
     try left_wall.setTransform(
         identity
             .scale(10.0, 0.01, 10.0)
@@ -33,7 +33,7 @@ pub fn renderSimpleWorld() !void {
     left_wall.material.color = Color(f64).new(0.9, 1.0, 0.9);
     left_wall.material.specular = 0.0;
 
-    var right_wall = Sphere(f64).new();
+    var right_wall = Shape(f64).sphere();
     try right_wall.setTransform(
         identity
             .scale(10.0, 0.01, 10.0)
@@ -44,19 +44,19 @@ pub fn renderSimpleWorld() !void {
     right_wall.material.color = Color(f64).new(0.9, 0.9, 1.0);
     right_wall.material.specular = 0.0;
 
-    var middle = Sphere(f64).new();
+    var middle = Shape(f64).sphere();
     try middle.setTransform(identity.translate(-0.5, 1.0, 0.5));
     middle.material.color = Color(f64).new(0.1, 1.0, 0.5);
     middle.material.diffuse = 0.7;
     middle.material.specular = 0.3;
 
-    var right = Sphere(f64).new();
+    var right = Shape(f64).sphere();
     try right.setTransform(identity.scale(0.5, 0.5, 0.5).translate(1.5, 0.5, -0.5));
     right.material.color = Color(f64).new(0.5, 1.0, 0.1);
     right.material.diffuse = 0.7;
     right.material.specular = 0.3;
 
-    var left = Sphere(f64).new();
+    var left = Shape(f64).sphere();
     try left.setTransform(identity.scale(0.33, 0.33, 0.33).translate(-1.5, 0.33, -0.75));
     left.material.color = Color(f64).new(1.0, 0.8, 0.1);
     left.material.diffuse = 0.7;

--- a/src/examples/sphere.zig
+++ b/src/examples/sphere.zig
@@ -6,8 +6,8 @@ const Canvas = @import("../raytracer/canvas.zig").Canvas;
 const Tuple = @import("../raytracer/tuple.zig").Tuple;
 const Matrix = @import("../raytracer/matrix.zig").Matrix;
 const Ray = @import("../raytracer/ray.zig").Ray;
-const Sphere = @import("../raytracer/shapes/sphere.zig").Sphere;
-const hit = @import("../raytracer/shapes/sphere.zig").hit;
+const Shape = @import("../raytracer/shapes/shape.zig").Shape;
+const hit = @import("../raytracer/shapes/shape.zig").hit;
 const Light = @import("../raytracer/light.zig").Light;
 
 pub fn drawSphere() !void {
@@ -19,7 +19,7 @@ pub fn drawSphere() !void {
 
     var canvas = try Canvas(f32).new(allocator, canvas_size, canvas_size);
 
-    var s = Sphere(f32).new();
+    var s = Shape(f32).sphere();
     s.material.color = Color(f32).new(1.0, 0.2, 1.0);
 
     const eye = Tuple(f32).point(0.0, 0.0, -5.0);
@@ -51,7 +51,6 @@ pub fn drawSphere() !void {
                 const normal = s.normalAt(point);
                 const eyev = ray.direction.negate();
                 const color = s.material.lighting(light, point, eyev, normal, false);
-
                 canvas.getPixelPointer(x, y).?.* = color;
             }
 

--- a/src/raytracer/shapes/shape.zig
+++ b/src/raytracer/shapes/shape.zig
@@ -1,0 +1,170 @@
+const std = @import("std");
+const testing = std.testing;
+const Allocator = std.mem.Allocator;
+const ArrayList = std.ArrayList;
+
+const Tuple = @import("../tuple.zig").Tuple;
+const Matrix = @import("../matrix.zig").Matrix;
+const Material = @import("../material.zig").Material;
+const Ray = @import("../ray.zig").Ray;
+const Sphere = @import("sphere.zig").Sphere;
+
+const global = struct {
+    var id: usize = 0;
+};
+
+
+pub fn Intersection(comptime T: type) type {
+    return struct {
+        const Self = @This();
+        t: T,
+        object: Shape(T),
+
+        pub fn new(t: T, object: Shape(T)) Self {
+            return .{ .t = t, .object = object };
+        }
+    };
+}
+
+fn IntersectionCmp(comptime T: type) type {
+    return struct {
+        fn call(context: void, a: Intersection(T), b: Intersection(T)) bool {
+            _ = context;
+
+            if (a.t > 0.0 and b.t < 0.0) {
+                return true;
+            } else if (a.t < 0.0 and b.t > 0.0) {
+                return false;
+            }
+
+            return std.sort.asc(T)({}, a.t, b.t);
+        }
+    };
+}
+
+pub fn Intersections(comptime T: type) type {
+    return ArrayList(Intersection(T));
+}
+
+
+pub fn sortIntersections(comptime T: type, intersections: *Intersections(T)) void {
+    std.sort.sort(Intersection(T), intersections.items[0..], {}, IntersectionCmp(T).call);
+}
+
+pub fn hit(comptime T: type, intersections: Intersections(T)) ?Intersection(T) {
+    var min: ?Intersection(T) = null;
+
+    for (intersections.items) |item| {
+        if (min) |_| {
+            if (IntersectionCmp(T).call({}, item, min.?)) {
+                min = item;
+            }
+        } else if (item.t >= 0.0) {
+            min = item;
+        }
+    }
+
+    return min;
+}
+
+pub fn Shape(comptime T: type) type {
+    return struct {
+        const Self = @This();
+
+        const Variant = union(enum) {
+            test_shape: TestShape(T),
+            sphere: Sphere(T),
+        };
+
+        id: usize,
+        _transform: Matrix(T, 4) = Matrix(T, 4).identity(),
+        _inverse_transform: Matrix(T, 4) = Matrix(T, 4).identity(),
+        _inverse_transform_transpose: Matrix(T, 4) = Matrix(T, 4).identity(),
+        material: Material(T) = Material(T).new(),
+        _saved_ray: ?Ray(T) = null,
+        variant: Variant,
+
+        fn new(variant: Variant) Self {
+            const save = global.id;
+            global.id += 1;
+
+            return .{ .id = save, .variant = variant };
+        }
+
+        pub fn testShape() Self {
+            return Shape(T).new(Shape(T).Variant { .test_shape = TestShape(T).new() });
+        }
+
+        pub fn sphere() Self {
+            return Shape(T).new(Shape(T).Variant { .sphere = Sphere(T) {} });
+        }
+
+        pub fn setTransform(self: *Self, matrix: Matrix(T, 4)) !void {
+            self._transform = matrix;
+            self._inverse_transform = try matrix.inverse();
+            self._inverse_transform_transpose = self._inverse_transform.transpose();
+        }
+
+        pub fn intersect(self: *Self, allocator: Allocator, ray: Ray(T)) !Intersections(T) {
+            self._saved_ray = ray.transform(self._inverse_transform);
+            switch (self.variant) {
+                inline else => |s| { return s.localIntersect(allocator, self.*, self._saved_ray.?); },
+            }
+        }
+
+        pub fn normalAt(self: Self, point: Tuple(T)) Tuple(T) {
+            const local_point = self._inverse_transform.tupleMul(point);
+            // Be very careful with this switch statement. If you try to assign to
+            // local_normal with a switch expression instead of jamming the rest of the
+            // function in the inline else, the compiler will lose its fucking mind and
+            // optimize out the entire switch in release mode.
+            switch (self.variant) {
+                inline else => |s| {
+                    const local_normal = s.localNormalAt(self, local_point);
+                    var world_normal = self._inverse_transform_transpose.tupleMul(local_normal);
+                    world_normal.w = 0.0;
+                    return world_normal.normalized();
+                },
+            }
+
+        }
+    };
+}
+
+fn TestShape(comptime T: type) type {
+    return struct {
+        const Self = @This();
+
+        pub fn new() Self {
+            return .{};
+        }
+
+        pub fn localIntersect(self: Self, allocator: Allocator, super: Shape(T), ray: Ray(T)) !Intersections(T) {
+            _ = self;
+            _ = super;
+            _ = ray;
+            return Intersections(T).init(allocator);
+        }
+
+        pub fn localNormalAt(self: Self, super: Shape(T), point: Tuple(T)) Tuple(T) {
+            _ = self;
+            _ = super;
+            _ = point;
+            return Tuple(T).point(0.0, 0.0, 0.0);
+        }
+    };
+}
+
+test "Creation" {
+    var s = Shape(f32).testShape();
+    try testing.expect(s._transform.approxEqual(Matrix(f32, 4).identity()));
+
+    s = Shape(f32).testShape();
+    try s.setTransform(Matrix(f32, 4).identity().translate(2.0, 3.0, 4.0));
+    try testing.expect(
+        s._transform.approxEqual(Matrix(f32, 4).identity().translate(2.0, 3.0, 4.0))
+    );
+    try testing.expect(
+        s._inverse_transform.approxEqual(Matrix(f32, 4).identity().translate(-2.0, -3.0, -4.0))
+    );
+}

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -4,9 +4,10 @@ comptime {
     _ = @import("raytracer/canvas.zig");
     _ = @import("raytracer/matrix.zig");
     _ = @import("raytracer/ray.zig");
-    _ = @import("raytracer/shapes/sphere.zig");
     _ = @import("raytracer/light.zig");
     _ = @import("raytracer/material.zig");
     _ = @import("raytracer/world.zig");
     _ = @import("raytracer/camera.zig");
+    _ = @import("raytracer/shapes/shape.zig");
+    _ = @import("raytracer/shapes/sphere.zig");
 }


### PR DESCRIPTION
There were a two options I considered for generalizing common behavior for shapes in the Ray tracer:

1. Let `Shape(T)` be a sum type over `Shere(T)`, `Plane(T)`, etc., using Zig's tagged unions, and use duck typing to mimic Rust traits.
2. Use C-style struct inheritance with a vtable and pointer fiddling.

Option 1 is nice because we never chase around function pointers, and the compiler can have a field day with inling. But it has the downside of bundling interface and implementers. Zig's sum type syntax also kind of sucks.

The upside of option 2 is the removal of implementers from the Shape interface definition, but, along with a potential slight performance hit, the interface exposed as a field on the implementer is actually pretty burdensome on the API (e.g. `sphere.shape.material` instead of `sphere.material`). I was also unhappy with the pervasive `extern`ing to force a well-defined position for the vtable within the implementer struct, but it turns out this is probably avoidable with `@fieldParentPtr`.

To address performance, I ran a simple benchmark of no-shape-abstraction vs. tagged-unions vs. vtables:

```shell
$ hyperfine --prepare 'git checkout main; zig build -Drelease-fast' 'zig-out/bin/ray-tracer-challenge' \
--prepare 'git checkout tagged-union; zig build -Drelease-fast' 'zig-out/bin/ray-tracer-challenge' \
--prepare 'git checkout struct-inheritance; zig build -Drelease-fast' 'zig-out/bin/ray-tracer-challenge'
Benchmark 1: zig-out/bin/ray-tracer-challenge
  Time (mean ± σ):      9.215 s ±  0.344 s    [User: 4.930 s, System: 4.065 s]
  Range (min … max):    8.586 s …  9.674 s    10 runs

Benchmark 2: zig-out/bin/ray-tracer-challenge
  Time (mean ± σ):      9.872 s ±  0.286 s    [User: 5.554 s, System: 4.166 s]
  Range (min … max):    9.385 s … 10.253 s    10 runs

Benchmark 3: zig-out/bin/ray-tracer-challenge
  Time (mean ± σ):     10.107 s ±  0.325 s    [User: 5.662 s, System: 4.278 s]
  Range (min … max):    9.730 s … 10.553 s    10 runs

Summary
  zig-out/bin/ray-tracer-challenge ran
    1.07 ± 0.05 times faster than zig-out/bin/ray-tracer-challenge
    1.10 ± 0.05 times faster than zig-out/bin/ray-tracer-challenge
```

As expected, the vtable implementation might be slightly slower than the tagged union. But surprisingly, even the tagged union was noticeably worse than the no-shape-abstraction version. Other runs of the same benchmark showed the same pattern.

Ultimately, these slight performance hits are not very important. I'm choosing tagged unions as the backing for my common-behavior abstractions going forward in this project based on the cleaner code they support.


 